### PR TITLE
Fix UniquesTransfer mapping (from, to)

### DIFF
--- a/src/mappings/mappingUniquesHandlers.ts
+++ b/src/mappings/mappingUniquesHandlers.ts
@@ -16,7 +16,7 @@ export async function handleUniquesTransferEvent(
   uniqueTransfer.block = event.block.block.header.number.toNumber();
   uniqueTransfer.txHash = txHash;
   uniqueTransfer.from = from.toString();
-  uniqueTransfer.toId = to.toString();
+  uniqueTransfer.to = to.toString();
   uniqueTransfer.collectionId = collectionId.toString();
   uniqueTransfer.itemId = itemId.toString();
   uniqueTransfer.timestamp = new Date(

--- a/src/mappings/mappingUniquesHandlers.ts
+++ b/src/mappings/mappingUniquesHandlers.ts
@@ -1,21 +1,27 @@
 import { SubstrateEvent } from "@subql/types";
 import { UniquesTransfer } from "../types/models";
 
-export async function handleUniquesTransferEvent(event: SubstrateEvent): Promise<void> {
-    logger.debug('uniqueTransferEvent added'  + JSON.stringify(event.toHuman()))
-    const from = event.event.data[0];
-    const to = event.event.data[1];
-    const collectionId = event.event.data[2];
-    const itemId = event.event.data[3];
-    const uniqueTransfer = new UniquesTransfer(`${event.block.block.header.number.toNumber()}-${event.idx}`);
-    const txHash = event.extrinsic.extrinsic.hash.toString();
-    uniqueTransfer.block = event.block.block.header.number.toNumber();
-    uniqueTransfer.txHash = txHash;
-    uniqueTransfer.fromId = from.toString();
-    uniqueTransfer.toId = to.toString();
-    uniqueTransfer.collectionId = collectionId.toString();
-    uniqueTransfer.itemId = itemId.toString();
-    uniqueTransfer.timestamp = new Date(event.extrinsic.block.timestamp).getTime();
+export async function handleUniquesTransferEvent(
+  event: SubstrateEvent
+): Promise<void> {
+  logger.debug("uniqueTransferEvent added" + JSON.stringify(event.toHuman()));
+  const from = event.event.data[0];
+  const to = event.event.data[1];
+  const collectionId = event.event.data[2];
+  const itemId = event.event.data[3];
+  const uniqueTransfer = new UniquesTransfer(
+    `${event.block.block.header.number.toNumber()}-${event.idx}`
+  );
+  const txHash = event.extrinsic.extrinsic.hash.toString();
+  uniqueTransfer.block = event.block.block.header.number.toNumber();
+  uniqueTransfer.txHash = txHash;
+  uniqueTransfer.from = from.toString();
+  uniqueTransfer.toId = to.toString();
+  uniqueTransfer.collectionId = collectionId.toString();
+  uniqueTransfer.itemId = itemId.toString();
+  uniqueTransfer.timestamp = new Date(
+    event.extrinsic.block.timestamp
+  ).getTime();
 
-    return uniqueTransfer.save();
+  return uniqueTransfer.save();
 }


### PR DESCRIPTION
It seemed that `UniquesTransfer` didn't have the fields `fromId` or `toId`, and instead had mappings the values (`from`, `to`) directly.

This PR attempts to correct this and resolve build issues.