### PR TITLE
Dockerfile: set --worker, --log-level and --batch-size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN cd app\
     && yarn install\
     && yarn codegen && yarn build
 
-CMD ["-f=/app", "--db-schema=app", "--log-level=debug", "--disable-historical=false", "--progress=plain"]
+CMD ["-f=/app", "--db-schema=app", "--log-level=info", "--disable-historical=false", "--worker=5", "--batch-size=50"]


### PR DESCRIPTION
Raise values for --worker to 5 and --batch-size to 50 on subquery node.
Set --log-level to "info"