### PR TITLE
General: reduce handlers to avoid on mapping chain queries state

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -29,36 +29,11 @@ dataSources:
           filter:
             module: balances
             method: Transfer
-        - handler: handleBalanceDepositEvent
-          kind: substrate/EventHandler
-          filter:
-            module: balances
-            method: Deposit
-        - handler: handleVestingScheduleAddedEvent
-          kind: substrate/EventHandler
-          filter:
-            module: vesting
-            method: VestingScheduleAdded
         - handler: handleUniquesTransferEvent
           kind: substrate/EventHandler
           filter:
             module: uniques
             method: Transferred
-        - handler: handleNewAccountEvent
-          kind: substrate/EventHandler
-          filter:
-            module: system
-            method: NewAccount
-        - handler: handleKilledAccountEvent
-          kind: substrate/EventHandler
-          filter:
-            module: system
-            method: KilledAccount
-        - handler: handleCancelAllVestingSchedulesCall
-          kind: substrate/CallHandler
-          filter:
-            module: vesting
-            method: cancelAllVestingSchedules
         - handler: handleAllocationBatchCall
           kind: substrate/CallHandler
           filter:

--- a/src/mappings/mappingBalanceHandlers.ts
+++ b/src/mappings/mappingBalanceHandlers.ts
@@ -22,7 +22,7 @@ export async function handleBalanceTransferEvent(event: SubstrateEvent) {
     record.timestamp = new Date(event.extrinsic.block.timestamp).getTime();
     record.success = checkIfExtrinsicExecuteSuccess(event.extrinsic)
 
-    return Promise.all([record.save(), updateAccountBalances([from.toString(), to.toString()])]);
+    return record.save();
 }
 
 export async function handleBalanceDepositEvent(event: SubstrateEvent) {


### PR DESCRIPTION
This is intended, so we plans to separate the handlers that require on mapping chain queries state such as:
- Account balances
- Vesting schedules